### PR TITLE
Enhance security and permission checks

### DIFF
--- a/actions/checkPermissions.ts
+++ b/actions/checkPermissions.ts
@@ -1,0 +1,36 @@
+import fs from "fs";
+import path from "path";
+
+const ROUTER_DIR = path.join(__dirname, "../src/routers");
+const IGNORED_FILES = new Set(["auth.ts", "socket.ts", "api.ts"]);
+
+function checkFile(filePath: string) {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const routeRegex = /router\.(get|post|put|delete|patch)\(([\s\S]*?)\);/g;
+  let match;
+  const missing: string[] = [];
+  while ((match = routeRegex.exec(content)) !== null) {
+    if (!match[2].includes("hasPermission")) {
+      missing.push(match[0].trim());
+    }
+  }
+  if (missing.length > 0) {
+    console.log(`Missing hasPermission in ${filePath}:`);
+    missing.forEach((r) => console.log(`  ${r}`));
+  }
+}
+
+function walkDir(dir: string) {
+  const files = fs.readdirSync(dir);
+  files.forEach((file) => {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+    if (stat.isDirectory()) {
+      walkDir(filePath);
+    } else if (file.endsWith(".ts") && !IGNORED_FILES.has(file)) {
+      checkFile(filePath);
+    }
+  });
+}
+
+walkDir(ROUTER_DIR);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "server:dev": "concurrently \"npx tsc --watch\" \"env-cmd -f .env.production npm run nodemon\" \"nodemon -x tsoa spec\"",
     "entity": "typeorm entity:create src/entity/ex",
     "start:debug": "concurrently \"npx tsc --watch\" \"env-cmd -f .env.local nodemon --inspect build/index.js\"",
-    "generate-types": "env-cmd -f .env.local ts-node actions/generateTypes.ts"
+    "generate-types": "env-cmd -f .env.local ts-node actions/generateTypes.ts",
+    "check:permissions": "ts-node actions/checkPermissions.ts"
   },
   "devDependencies": {
     "@types/compression": "^1.7.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import configureMorgan from "./config/log";
 import { ORIGIN, __prod__ } from "./constants";
 import { AppDataSource } from "./data-source";
 
-import { socketMiddleware } from "./middlewares";
+import { socketMiddleware, csrfProtection } from "./middlewares";
 import { setupRouters } from "./routers";
 import socket from "./routers/socket";
 import { generateMergedSwaggerSpec } from "./swagger";
@@ -35,6 +35,7 @@ AppDataSource.initialize()
     app.use(express.json({ limit: "64mb" }));
     app.use(express.urlencoded({ limit: "64mb", extended: true }));
     app.use(cookieParser());
+    app.use(csrfProtection);
     app.use(
       cors({
         origin: "*",
@@ -84,6 +85,9 @@ AppDataSource.initialize()
     const mergedSwaggerSpec = generateMergedSwaggerSpec();
     app.use("/docs", swaggerUi.serve, swaggerUi.setup(mergedSwaggerSpec));
     app.use(setLocale);
+    app.get("/csrf-token", (req, res) => {
+      res.json({ csrfToken: req.cookies["csrf-token"] });
+    });
     const apiRouter = await setupRouters();
     app.use("/", apiRouter);
     app.use((_req, res) => {

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -3,6 +3,7 @@ import { DefaultEventsMap } from "socket.io/dist/typed-events";
 import { Socket } from "socket.io";
 import { Request, Response, NextFunction } from "express-serve-static-core";
 import { JwtVerifyAccessToken } from "../utils";
+import addLog from "../config/addLog";
 
 export const authAccessToken = async (req: Request, res: Response, next: NextFunction) => {
 	try {
@@ -10,31 +11,34 @@ export const authAccessToken = async (req: Request, res: Response, next: NextFun
 			? req.header("Authorization")?.split(" ")[1]
 			: req.cookies["token"];
 
-		if (!accessToken) {
-			return res.status(401).json({
-				code: 401,
-				success: false,
-				message: "Access token provided!",
-			});
-		}
-		const decodedUser = await JwtVerifyAccessToken(accessToken as string);
-		if (decodedUser.error) {
-			return res.status(401).send({
-				code: 401,
-				success: false,
-				message: decodedUser.error.message,
-			});
-		}
+                if (!accessToken) {
+                        addLog("Access token is missing", "error");
+                        return res.status(401).json({
+                                code: 401,
+                                success: false,
+                                message: "Access token is missing!",
+                        });
+                }
+                const decodedUser = await JwtVerifyAccessToken(accessToken as string);
+                if (decodedUser.error) {
+                        addLog(decodedUser.error.message, "error");
+                        return res.status(401).send({
+                                code: 401,
+                                success: false,
+                                message: decodedUser.error.message,
+                        });
+                }
 
 		req.userId = decodedUser.data?.userId;
 		return next();
 	} catch (error) {
-		return res.status(500).json({
-			code: 500,
-			success: false,
-			message: "Server",
-		});
-	}
+                addLog(error, "error");
+                return res.status(500).json({
+                        code: 500,
+                        success: false,
+                        message: "Server error",
+                });
+        }
 };
 
 export const socketMiddleware = async (

--- a/src/middlewares/csrf.ts
+++ b/src/middlewares/csrf.ts
@@ -1,0 +1,43 @@
+import { Request, Response, NextFunction } from "express";
+import crypto from "crypto";
+import addLog from "../config/addLog";
+
+const IGNORED_METHODS = ["GET", "HEAD", "OPTIONS"];
+
+export const csrfProtection = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    if (IGNORED_METHODS.includes(req.method)) {
+      if (!req.cookies["csrf-token"]) {
+        const token = crypto.randomBytes(24).toString("hex");
+        res.cookie("csrf-token", token, {
+          httpOnly: false,
+          sameSite: "strict",
+        });
+      }
+      return next();
+    }
+
+    const tokenFromCookie = req.cookies["csrf-token"];
+    const tokenFromHeader = req.header("x-csrf-token");
+    if (tokenFromCookie && tokenFromHeader && tokenFromCookie === tokenFromHeader) {
+      return next();
+    }
+    addLog(`CSRF token mismatch`, "error");
+    return res.status(403).json({
+      code: 403,
+      success: false,
+      message: "Invalid CSRF token",
+    });
+  } catch (error) {
+    addLog(error, "error");
+    return res.status(500).json({
+      code: 500,
+      success: false,
+      message: "CSRF protection error",
+    });
+  }
+};

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,3 +1,4 @@
 export * from "./auth";
 export * from "./validate";
 export * from "./permission";
+export * from "./csrf";

--- a/src/middlewares/permission.ts
+++ b/src/middlewares/permission.ts
@@ -2,20 +2,23 @@ import { NextFunction, Request, Response } from "express";
 import { getPermissionByRoleIdByResource } from "../services/permission";
 import { getUserOrRole } from "../services/user";
 import { Action, Permission, Resource } from "../types/permissions";
+import addLog from "../config/addLog";
 
 export const hasPermission = (resource: Resource, action: Action) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       if (!req.userId) {
+        addLog("Unauthorized access - missing userId", "error");
         return res.status(401).json({
           code: 401,
           success: false,
-          error: [`AuthorizeUser is not logged in yet`],
+          error: ["User is not authenticated"],
         });
       }
 
       const user = await getUserOrRole(req.userId);
       if (!user || !user.role) {
+        addLog(`User ${req.userId} has no role`, "error");
         return res.status(401).json({
           code: 401,
           success: false,
@@ -36,6 +39,10 @@ export const hasPermission = (resource: Resource, action: Action) => {
       );
 
       if (!permission) {
+        addLog(
+          `Role ${user.role.id} lacks permission ${permissionResource}`,
+          "error"
+        );
         return res.status(401).json({
           code: 401,
           success: false,
@@ -44,10 +51,11 @@ export const hasPermission = (resource: Resource, action: Action) => {
       }
       return next();
     } catch (error) {
+      addLog(error, "error");
       return res.status(500).json({
         code: 500,
         success: false,
-        error: [`Error checking permissions`],
+        error: ["Error checking permissions"],
       });
     }
   };

--- a/src/services/permission.ts
+++ b/src/services/permission.ts
@@ -2,6 +2,7 @@ import { EntityManager } from "typeorm";
 import { PERMISSIONS_ACTIONS } from "../constants";
 import { AppDataSource } from "../data-source";
 import { Permissions } from "../entity/Permissions";
+import redisClient from "../redis";
 
 export type IPermissionPayload = Omit<
   Permissions,
@@ -138,10 +139,21 @@ export const getPermissionByRoleIdByResource = async (
   if (roleId === undefined) {
     return null;
   }
+  const cacheKey = `perm:${roleId}:${resource}`;
+  try {
+    const cached = await redisClient.get(cacheKey);
+    if (cached) {
+      return JSON.parse(cached) as Permissions;
+    }
+  } catch (_e) {}
+
   const permission = await Permissions.findOne({
     where: { role_id: roleId, resource: resource },
   });
   if (!permission) return null;
+  try {
+    await redisClient.set(cacheKey, JSON.stringify(permission), "EX", 300);
+  } catch (_e) {}
   return permission;
 };
 export const getEntityTableNames = async () => {


### PR DESCRIPTION
## Summary
- Clarify auth errors and log authentication failures
- Log missing roles and permissions and cache role permissions in Redis
- Add custom CSRF protection and a script to audit routes for missing `hasPermission`

## Testing
- `npm run check:permissions`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af18972384832aade0ba7beb3ccdc2