### PR TITLE
feat: reload entities on json change

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,20 +45,20 @@
     "typescript": "^5.5.3"
   },
   "dependencies": {
+    "@apollo/server": "^4.11.0",
     "argon2": "^0.40.3",
     "axios": "^1.7.7",
     "cheerio": "^1.0.0",
-    "@apollo/server": "^4.11.0",
-    "dataloader": "^2.2.2",
-    "graphql": "^16.8.1",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
+    "dataloader": "^2.2.2",
     "dotenv": "^17.0.1",
     "env-cmd": "^10.1.0",
     "eventemitter3": "^5.0.1",
     "express": "^4.19.2",
     "express-validator": "^7.1.0",
+    "graphql": "^16.8.1",
     "helmet": "^7.1.0",
     "ioredis": "^5.4.1",
     "jsonwebtoken": "^9.0.2",
@@ -79,7 +79,8 @@
     "tsoa": "^6.4.0",
     "typeorm": "^0.3.20",
     "uuid": "^10.0.0",
-    "web-push": "^3.6.7"
+    "web-push": "^3.6.7",
+    "chokidar": "^3.6.0"
   },
   "resolutions": {
     "string-width": "^4.2.0",

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -16,35 +16,43 @@ import { User } from "./entity/User";
 import { loadDynamicEntities } from "./loaders/entity.loader";
 import type { DynamicRegistry } from "./loaders/entity.loader";
 
-// Tải các entity động từ file JSON
-const definitionsDir = path.join(__dirname, "definitions");
-export const dynamicRegistry: DynamicRegistry = loadDynamicEntities(definitionsDir);
-const dynamicEntities = Array.from(dynamicRegistry.schemas.values());
+export let dynamicRegistry: DynamicRegistry;
+export let AppDataSource: DataSource;
 
-export const AppDataSource = new DataSource({
-  type: "mysql",
-  host: process.env.DB_HOST,
-  port: 3306,
-  username: process.env.DB_USERNAME,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_DATABASE,
-  synchronize: true,
-  logging: false,
-  ...(__prod__ ? {} : { synchronize: true }),
-  entities: [
-    User,
-    Role,
-    Permissions,
-    File,
-    Device,
-    Bookmark,
-    BookmarkTag,
-    Tag,
-    Bot,
-    CallbackQuery,
-    Message,
-    ...dynamicEntities,
-  ],
+export const initDataSource = async (): Promise<void> => {
+  // Tải các entity động từ file JSON
+  const definitionsDir = path.join(__dirname, "definitions");
+  dynamicRegistry = loadDynamicEntities(definitionsDir);
+  const dynamicEntities = Array.from(dynamicRegistry.schemas.values());
 
-  migrations: [path.join(__dirname, "/migrations/*")],
-});
+  AppDataSource = new DataSource({
+    type: "mysql",
+    host: process.env.DB_HOST,
+    port: 3306,
+    username: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_DATABASE,
+    synchronize: true,
+    logging: false,
+    ...(__prod__ ? {} : { synchronize: true }),
+    entities: [
+      User,
+      Role,
+      Permissions,
+      File,
+      Device,
+      Bookmark,
+      BookmarkTag,
+      Tag,
+      Bot,
+      CallbackQuery,
+      Message,
+      ...dynamicEntities,
+    ],
+
+    migrations: [path.join(__dirname, "/migrations/*")],
+  });
+
+  await AppDataSource.initialize();
+};
+

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -7,7 +7,7 @@ export interface GraphQLContext {
   req: Request;
 }
 
-export const createGraphQLMiddleware = async () => {
+export const makeExecutableDocuments = async () => {
   const schema = buildSchema();
   const server = new ApolloServer<GraphQLContext>({ schema });
   await server.start();
@@ -15,3 +15,5 @@ export const createGraphQLMiddleware = async () => {
     context: async ({ req }: { req: Request }) => ({ req }),
   });
 };
+
+export const createGraphQLMiddleware = makeExecutableDocuments;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,26 +10,45 @@ import path from "path";
 import "reflect-metadata";
 import { Server as SocketIO } from "socket.io";
 import swaggerUi from "swagger-ui-express";
+import chokidar from "chokidar";
 import addLog from "./config/addLog";
 import configureMorgan from "./config/log";
 import { ORIGIN, __prod__ } from "./constants";
-import { AppDataSource } from "./data-source";
+import { AppDataSource, initDataSource } from "./data-source";
 
 import { socketMiddleware, csrfProtection, authAccessToken } from "./middlewares";
 import { setupRouters } from "./routers";
 import socket from "./routers/socket";
 import { generateMergedSwaggerSpec } from "./swagger";
 import { i18n, setLocale } from "./translation";
-import { createGraphQLMiddleware } from "./graphql";
+import { makeExecutableDocuments } from "./graphql";
 dotenv.config();
 
 const logDirectory = path.join(__dirname, "logs");
-AppDataSource.initialize()
+let isReloading = false;
+const waitForUnlock = () =>
+  new Promise<void>((resolve) => {
+    if (!isReloading) return resolve();
+    const timer = setInterval(() => {
+      if (!isReloading) {
+        clearInterval(timer);
+        resolve();
+      }
+    }, 10);
+  });
+
+initDataSource()
   .then(async () => {
     const app: Express = express();
     const server = new http.Server(app);
 
     const port = process.env.PORT;
+
+    // Middleware để chờ mutex khi reload
+    app.use(async (_req, _res, next) => {
+      await waitForUnlock();
+      next();
+    });
 
     app.use(express.json({ limit: "64mb" }));
     app.use(express.urlencoded({ limit: "64mb", extended: true }));
@@ -75,8 +94,10 @@ AppDataSource.initialize()
     const mergedSwaggerSpec = generateMergedSwaggerSpec();
     app.use("/docs", swaggerUi.serve, swaggerUi.setup(mergedSwaggerSpec));
     app.use(setLocale);
-    const graphqlMiddleware = await createGraphQLMiddleware();
-    app.use("/graphql", authAccessToken, graphqlMiddleware);
+    let graphqlMiddleware = await makeExecutableDocuments();
+    app.use("/graphql", authAccessToken, (req, res, next) =>
+      graphqlMiddleware(req, res, next)
+    );
     app.get("/csrf-token", (req, res) => {
       res.json({ csrfToken: req.cookies["csrf-token"] });
     });
@@ -106,6 +127,26 @@ AppDataSource.initialize()
       socketMiddleware(socket, next);
     });
     socket(io);
+
+    const watcher = chokidar.watch(
+      path.join(__dirname, "definitions", "*.json"),
+      { ignoreInitial: true }
+    );
+    watcher.on("all", async () => {
+      isReloading = true;
+      try {
+        await AppDataSource.destroy();
+        await initDataSource();
+        graphqlMiddleware = await makeExecutableDocuments();
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setTimeout(() => {
+          isReloading = false;
+        }, 300);
+      }
+    });
+
     // startSync();
     server.listen(port, () => {
       process.on("exit", function () {


### PR DESCRIPTION
## Summary
- hot reload entity definitions and datasource when JSON changes
- rebuild GraphQL middleware with fresh schema
- block incoming requests for brief reload window

## Testing
- `pnpm install` *(fails: Request was cancelled)*
- `npm test` *(fails: Missing script: "test")*
- `tsc -p tsconfig.prod.json` *(fails: Argument of type 'Buffer' is not assignable to parameter of type ...)*


------
https://chatgpt.com/codex/tasks/task_e_68af9d1eed0c832ab932011aebc27f80