### PR TITLE
feat: enable graphql subscriptions with websocket support

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,10 @@
     "typeorm": "^0.3.20",
     "uuid": "^10.0.0",
     "web-push": "^3.6.7",
-    "chokidar": "^3.6.0"
+    "chokidar": "^3.6.0",
+    "graphql-ws": "^5.14.0",
+    "ws": "^8.17.0",
+    "graphql-subscriptions": "^2.0.0"
   },
   "resolutions": {
     "string-width": "^4.2.0",

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -11,9 +11,14 @@ export const makeExecutableDocuments = async () => {
   const schema = buildSchema();
   const server = new ApolloServer<GraphQLContext>({ schema });
   await server.start();
-  return expressMiddleware(server, {
-    context: async ({ req }: { req: Request }) => ({ req }),
-  });
+  return {
+    schema,
+    middleware: expressMiddleware(server, {
+      context: async ({ req }: { req: Request }) => ({ req }),
+    }),
+  };
 };
-
-export const createGraphQLMiddleware = makeExecutableDocuments;
+export const createGraphQLMiddleware = async () => {
+  const { middleware } = await makeExecutableDocuments();
+  return middleware;
+};

--- a/src/graphql/schema-builder.ts
+++ b/src/graphql/schema-builder.ts
@@ -12,6 +12,7 @@ import {
 import { AppDataSource, dynamicRegistry } from '../data-source';
 import { ensureAllowed } from './authz';
 import { buildFilter } from './filter-builder';
+import { pubsub } from '../pubsub';
 
 const scalarType = (t: string) => {
   switch (t) {
@@ -31,6 +32,7 @@ const scalarType = (t: string) => {
 export const buildSchema = () => {
   const queryFields: any = {};
   const mutationFields: any = {};
+  const subscriptionFields: any = {};
 
   for (const [entity, def] of dynamicRegistry.defs.entries()) {
     const fields: any = {};
@@ -108,7 +110,11 @@ export const buildSchema = () => {
       resolve: async (_src: any, { data }: any, ctx: any) => {
         ensureAllowed(ctx, entity, 'create');
         const obj = repo.create(data);
-        return repo.save(obj);
+        const saved = await repo.save(obj);
+        await pubsub.publish(`${entity.toUpperCase()}_CREATED`, {
+          [`${lc}Created`]: saved,
+        });
+        return saved;
       },
     };
 
@@ -134,9 +140,18 @@ export const buildSchema = () => {
         return true;
       },
     };
+
+    subscriptionFields[`${lc}Created`] = {
+      type,
+      subscribe: () => pubsub.asyncIterator(`${entity.toUpperCase()}_CREATED`),
+    };
   }
 
   const query = new GraphQLObjectType({ name: 'Query', fields: queryFields });
   const mutation = new GraphQLObjectType({ name: 'Mutation', fields: mutationFields });
-  return new GraphQLSchema({ query, mutation });
+  const subscription = new GraphQLObjectType({
+    name: 'Subscription',
+    fields: subscriptionFields,
+  });
+  return new GraphQLSchema({ query, mutation, subscription });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,10 @@ import "reflect-metadata";
 import { Server as SocketIO } from "socket.io";
 import swaggerUi from "swagger-ui-express";
 import chokidar from "chokidar";
+import { WebSocketServer } from "ws";
+import { useServer } from "graphql-ws/lib/use/ws";
+import { execute, subscribe } from "graphql";
+import type { ServerCleanup } from "graphql-ws";
 import addLog from "./config/addLog";
 import configureMorgan from "./config/log";
 import { ORIGIN, __prod__ } from "./constants";
@@ -94,9 +98,19 @@ initDataSource()
     const mergedSwaggerSpec = generateMergedSwaggerSpec();
     app.use("/docs", swaggerUi.serve, swaggerUi.setup(mergedSwaggerSpec));
     app.use(setLocale);
-    let graphqlMiddleware = await makeExecutableDocuments();
+    let { schema, middleware: graphqlMiddleware } = await makeExecutableDocuments();
     app.use("/graphql", authAccessToken, (req, res, next) =>
       graphqlMiddleware(req, res, next)
+    );
+    const wsServer = new WebSocketServer({ server, path: "/graphql" });
+    let serverCleanup: ServerCleanup = useServer(
+      {
+        schema,
+        execute,
+        subscribe,
+        context: (ctx) => ({ req: ctx.extra.request as any }),
+      },
+      wsServer
     );
     app.get("/csrf-token", (req, res) => {
       res.json({ csrfToken: req.cookies["csrf-token"] });
@@ -137,7 +151,19 @@ initDataSource()
       try {
         await AppDataSource.destroy();
         await initDataSource();
-        graphqlMiddleware = await makeExecutableDocuments();
+        const result = await makeExecutableDocuments();
+        schema = result.schema;
+        graphqlMiddleware = result.middleware;
+        await serverCleanup.dispose();
+        serverCleanup = useServer(
+          {
+            schema,
+            execute,
+            subscribe,
+            context: (ctx) => ({ req: ctx.extra.request as any }),
+          },
+          wsServer
+        );
       } catch (err) {
         console.error(err);
       } finally {

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -1,0 +1,3 @@
+import { PubSub } from 'graphql-subscriptions';
+
+export const pubsub = new PubSub();


### PR DESCRIPTION
## Summary
- add graphql-ws, ws and graphql-subscriptions deps
- expose a pubsub utility and extend schema builder with subscription fields
- start WebSocketServer on `/graphql` and publish events after entity creation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'ws', 'graphql-ws', 'graphql-subscriptions')*


------
https://chatgpt.com/codex/tasks/task_e_68af9f98f77c832abe5172f3889d03c3