### PR TITLE
feat: add typed filter validation

### DIFF
--- a/src/graphql/filter-builder.ts
+++ b/src/graphql/filter-builder.ts
@@ -1,10 +1,31 @@
+import { ListFilter, ValidatedFilter } from '../types';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+const ORDER_VALUES: Array<ListFilter['order']> = ['ASC', 'DESC'];
+
+export const validateFilter = (args: any = {}): ValidatedFilter => {
+  const page = Number.isInteger(args.page) && args.page > 0 ? args.page : DEFAULT_PAGE;
+  const limit = Number.isInteger(args.limit) && args.limit > 0 ? args.limit : DEFAULT_LIMIT;
+  const sort = typeof args.sort === 'string' && args.sort.length > 0 ? args.sort : undefined;
+  const order =
+    typeof args.order === 'string' && ORDER_VALUES.includes(args.order.toUpperCase())
+      ? (args.order.toUpperCase() as ListFilter['order'])
+      : undefined;
+  const where = typeof args.where === 'string' ? args.where : undefined;
+  const include = Array.isArray(args.include)
+    ? args.include.filter((v: unknown): v is string => typeof v === 'string')
+    : undefined;
+  return { page, limit, sort, order, where, include };
+};
+
 export const buildFilter = (args: any) => {
-  const { page = 1, limit = 20, sort, order, where, include } = args || {};
+  const { page, limit, sort, order, where, include } = validateFilter(args);
   const skip = (page - 1) * limit;
   const take = limit;
   const options: any = { skip, take };
   if (sort) {
-    options.order = { [sort]: (order || 'ASC').toUpperCase() };
+    options.order = { [sort]: order || 'ASC' };
   }
   if (where) {
     try {
@@ -18,3 +39,4 @@ export const buildFilter = (args: any) => {
   }
   return options;
 };
+

--- a/src/graphql/schema-builder.ts
+++ b/src/graphql/schema-builder.ts
@@ -12,6 +12,7 @@ import {
 import { AppDataSource, dynamicRegistry } from '../data-source';
 import { ensureAllowed } from './authz';
 import { buildFilter } from './filter-builder';
+import { ListFilter } from '../types';
 import { pubsub } from '../pubsub';
 
 const scalarType = (t: string) => {
@@ -71,7 +72,7 @@ export const buildSchema = () => {
         where: { type: GraphQLString },
         include: { type: new GraphQLList(GraphQLString) },
       },
-      resolve: async (_src: any, args: any, ctx: any) => {
+      resolve: async (_src: any, args: ListFilter & { q?: string }, ctx: any) => {
         ensureAllowed(ctx, entity, 'read');
         const opts = buildFilter(args);
         const [data, total] = await repo.findAndCount(opts as any);
@@ -97,7 +98,7 @@ export const buildSchema = () => {
         q: { type: GraphQLString },
         where: { type: GraphQLString },
       },
-      resolve: async (_src: any, args: any, ctx: any) => {
+      resolve: async (_src: any, args: ListFilter & { q?: string }, ctx: any) => {
         ensureAllowed(ctx, entity, 'read');
         const opts = buildFilter(args);
         return repo.count(opts as any);

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -1,0 +1,14 @@
+export interface ListFilter {
+  page?: number;
+  limit?: number;
+  sort?: string;
+  order?: 'ASC' | 'DESC';
+  where?: string;
+  include?: string[];
+}
+
+export type ValidatedFilter = Omit<ListFilter, 'page' | 'limit'> & {
+  page: number;
+  limit: number;
+};
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,5 @@ export * from "./error";
 export * from "./file";
 export * from "./response";
 export * from "./bot";
+export * from "./filter";
+


### PR DESCRIPTION
## Summary
- define typed `ListFilter` interfaces for reusable filter parameters
- validate and normalize query filters before building options
- apply typed filters in schema builder for stronger DX

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit` *(fails: Could not find a declaration file for module 'ws')*


------
https://chatgpt.com/codex/tasks/task_e_68afab78d408832aa962ac30f1a8f549